### PR TITLE
CSRF and SQL injection security patch

### DIFF
--- a/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/Grid.php
+++ b/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/Grid.php
@@ -1,186 +1,33 @@
 <?php
-class Raveinfosys_Deleteorder_Block_Adminhtml_Sales_Order_Grid extends Mage_Adminhtml_Block_Widget_Grid
+class Raveinfosys_Deleteorder_Block_Adminhtml_Sales_Order_Grid extends Mage_Adminhtml_Block_Sales_Order_Grid
 {
-    public function __construct()
-    {
-        parent::__construct();
-        $this->setId('sales_order_grid');
-        $this->setUseAjax(true);
-        $this->setDefaultSort('created_at');
-        $this->setDefaultDir('DESC');
-        $this->setSaveParametersInSession(true);
-    }
-
-    /**
-     * Retrieve collection class
-     *
-     * @return string
-     */
-    protected function _getCollectionClass()
-    {
-        return 'sales/order_grid_collection';
-    }
-
-    protected function _prepareCollection()
-    {
-        $collection = Mage::getResourceModel($this->_getCollectionClass());
-        $this->setCollection($collection);
-        return parent::_prepareCollection();
-    }
 
     protected function _prepareColumns()
     {
+        parent::_prepareColumns();
 
-        $this->addColumn('real_order_id', array(
-            'header'=> Mage::helper('sales')->__('Order #'),
-            'width' => '80px',
-            'type'  => 'text',
-            'index' => 'increment_id',
-        ));
-
-        if (!Mage::app()->isSingleStoreMode()) {
-            $this->addColumn('store_id', array(
-                'header'    => Mage::helper('sales')->__('Purchased From (Store)'),
-                'index'     => 'store_id',
-                'type'      => 'store',
-                'store_view'=> true,
-                'display_deleted' => true,
-            ));
+        $actionColumn = $this->getColumn('action');
+        if ($actionColumn !== false) {
+            unset($actionColumn['actions']);
+            $actionColumn['width']    = '100px';
+            $actionColumn['renderer'] = 'deleteorder/adminhtml_sales_order_render_delete';
         }
-
-        $this->addColumn('created_at', array(
-            'header' => Mage::helper('sales')->__('Purchased On'),
-            'index' => 'created_at',
-            'type' => 'datetime',
-            'width' => '100px',
-        ));
-
-        $this->addColumn('billing_name', array(
-            'header' => Mage::helper('sales')->__('Bill to Name'),
-            'index' => 'billing_name',
-        ));
-
-        $this->addColumn('shipping_name', array(
-            'header' => Mage::helper('sales')->__('Ship to Name'),
-            'index' => 'shipping_name',
-        ));
-
-        $this->addColumn('base_grand_total', array(
-            'header' => Mage::helper('sales')->__('G.T. (Base)'),
-            'index' => 'base_grand_total',
-            'type'  => 'currency',
-            'currency' => 'base_currency_code',
-        ));
-
-        $this->addColumn('grand_total', array(
-            'header' => Mage::helper('sales')->__('G.T. (Purchased)'),
-            'index' => 'grand_total',
-            'type'  => 'currency',
-            'currency' => 'order_currency_code',
-        ));
-
-        $this->addColumn('status', array(
-            'header' => Mage::helper('sales')->__('Status'),
-            'index' => 'status',
-            'type'  => 'options',
-            'width' => '70px',
-            'options' => Mage::getSingleton('sales/order_config')->getStatuses(),
-        ));
-
-        if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/view')) {
-            $this->addColumn('action',
-                array(
-                    'header'    => Mage::helper('sales')->__('Action'),
-                    'width'     => '100px',
-                    'type'      => 'action',
-                    'getter'     => 'getId',
-					'renderer'  => 'deleteorder/adminhtml_sales_order_render_delete',
-                    'filter'    => false,
-                    'sortable'  => false,
-                    'index'     => 'stores',
-                    'is_system' => true,
-            ));
-        }
-        $this->addRssList('rss/order/new', Mage::helper('sales')->__('New Order RSS'));
-
-        $this->addExportType('*/*/exportCsv', Mage::helper('sales')->__('CSV'));
-        $this->addExportType('*/*/exportExcel', Mage::helper('sales')->__('Excel XML'));
-
-        return parent::_prepareColumns();
+        return $this;
     }
 
     protected function _prepareMassaction()
     {
-        $this->setMassactionIdField('entity_id');
-        $this->getMassactionBlock()->setFormFieldName('order_ids');
-        $this->getMassactionBlock()->setUseSelectAll(false);
+        parent::_prepareMassaction();
 
-        if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/cancel')) {
-            $this->getMassactionBlock()->addItem('cancel_order', array(
-                 'label'=> Mage::helper('sales')->__('Cancel'),
-                 'url'  => $this->getUrl('*/sales_order/massCancel'),
-            ));
-        }
-
-        if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/hold')) {
-            $this->getMassactionBlock()->addItem('hold_order', array(
-                 'label'=> Mage::helper('sales')->__('Hold'),
-                 'url'  => $this->getUrl('*/sales_order/massHold'),
-            ));
-        }
-
-        if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/unhold')) {
-            $this->getMassactionBlock()->addItem('unhold_order', array(
-                 'label'=> Mage::helper('sales')->__('Unhold'),
-                 'url'  => $this->getUrl('*/sales_order/massUnhold'),
-            ));
-        }
-
-        $this->getMassactionBlock()->addItem('pdfinvoices_order', array(
-             'label'=> Mage::helper('sales')->__('Print Invoices'),
-             'url'  => $this->getUrl('*/sales_order/pdfinvoices'),
-        ));
-
-        $this->getMassactionBlock()->addItem('pdfshipments_order', array(
-             'label'=> Mage::helper('sales')->__('Print Packingslips'),
-             'url'  => $this->getUrl('*/sales_order/pdfshipments'),
-        ));
-
-        $this->getMassactionBlock()->addItem('pdfcreditmemos_order', array(
-             'label'=> Mage::helper('sales')->__('Print Credit Memos'),
-             'url'  => $this->getUrl('*/sales_order/pdfcreditmemos'),
-        ));
-
-        $this->getMassactionBlock()->addItem('pdfdocs_order', array(
-             'label'=> Mage::helper('sales')->__('Print All'),
-             'url'  => $this->getUrl('*/sales_order/pdfdocs'),
-        ));
-
-        $this->getMassactionBlock()->addItem('print_shipping_label', array(
-             'label'=> Mage::helper('sales')->__('Print Shipping Labels'),
-             'url'  => $this->getUrl('*/sales_order_shipment/massPrintShippingLabel'),
-        ));
-		
         $this->getMassactionBlock()->addItem('delete_order', array(
-             'label'=> Mage::helper('sales')->__('Delete Order'),
-             'url'  => $this->getUrl('*/deleteorder/massDelete'),
-			 'confirm'  => Mage::helper('sales')->__('Are you sure you want to delete order?')
-        ));		
+            'label'   => Mage::helper('sales')->__('Delete Order'),
+            'url'     => $this->getUrl('*/deleteorder/massDelete', array(
+                Mage_Core_Model_Url::FORM_KEY => $this->getFormKey()
+            )),
+            'confirm' => Mage::helper('sales')
+                             ->__('Are you sure you want to delete order?')
+        ));
 
         return $this;
     }
-    public function getRowUrl($row)
-    {
-        if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/view')) {
-            return $this->getUrl('*/sales_order/view', array('order_id' => $row->getId()));
-        }
-        return false;
-    }
-
-    public function getGridUrl()
-    {
-        return $this->getUrl('*/*/grid', array('_current'=>true));
-    }
-
 }
-?>

--- a/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/Render/Delete.php
+++ b/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/Render/Delete.php
@@ -7,12 +7,18 @@ class Raveinfosys_Deleteorder_Block_Adminhtml_Sales_Order_Render_Delete extends 
 		$message = Mage::helper('sales')->__('Are you sure you want to delete this order?');
 		$orderID = $getData['entity_id'];
         $view = $this->getUrl('*/sales_order/view',array('order_id' => $orderID));
-		$delete = $this->getUrl('*/deleteorder/delete',array('order_id' => $orderID));
+		$delete = $this->getDeleteUrl($orderID);
 		$link = '<a href="'.$view.'">View</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#" onclick="deleteConfirm(\''.$message.'\', \'' . $delete . '\')">Delete</a>';
 		return $link;
     }
 
-
+    public function getDeleteUrl($orderID)
+    {
+        return $this->getUrl('*/deleteorder/delete', array(
+            'order_id' => $orderID,
+            Mage_Core_Model_Url::FORM_KEY => $this->getFormKey()
+        ));
+    }
 }
 
 ?>

--- a/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/View.php
+++ b/app/code/community/Raveinfosys/Deleteorder/Block/Adminhtml/Sales/Order/View.php
@@ -10,10 +10,13 @@
             'class'     => 'go'
         ), 0, 100, 'header', 'header');
     }
-	
+
     public function getDeleteUrl()
     {
-        return $this->getUrl('*/deleteorder/delete', array('_current'=>true));
-    }	
+        return $this->getUrl('*/deleteorder/delete', array(
+            '_current'                    => true,
+            Mage_Core_Model_Url::FORM_KEY => $this->getFormKey()
+        ));
+    }
 }
 ?>

--- a/app/code/community/Raveinfosys/Deleteorder/controllers/Adminhtml/DeleteorderController.php
+++ b/app/code/community/Raveinfosys/Deleteorder/controllers/Adminhtml/DeleteorderController.php
@@ -30,6 +30,10 @@ class Raveinfosys_Deleteorder_Adminhtml_DeleteorderController extends Mage_Admin
 			->renderLayout();
 	}
 	public function deleteAction() {
+        if (!$this->_validateFormKey()) {
+            $this->_redirect('*/*/');
+            return;
+        }
 		if($order = $this->_initOrder()) {
 			try {
      		    $order->delete();
@@ -45,6 +49,10 @@ class Raveinfosys_Deleteorder_Adminhtml_DeleteorderController extends Mage_Admin
 		$this->_redirectUrl(Mage::helper('adminhtml')->getUrl('adminhtml/sales_order/index'));
 	}
     public function massDeleteAction() {
+        if (!$this->_validateFormKey()) {
+            $this->_redirect('*/*/');
+            return;
+        }
         $deleteorderIds = $this->getRequest()->getParam('order_ids');
 		if(!is_array($deleteorderIds)) {
 			Mage::getSingleton('adminhtml/session')->addError(Mage::helper('adminhtml')->__('Please select item(s)'));

--- a/app/code/community/Raveinfosys/Deleteorder/controllers/Adminhtml/DeleteorderController.php
+++ b/app/code/community/Raveinfosys/Deleteorder/controllers/Adminhtml/DeleteorderController.php
@@ -73,24 +73,29 @@ class Raveinfosys_Deleteorder_Adminhtml_DeleteorderController extends Mage_Admin
         }
 		$this->_redirectUrl(Mage::helper('adminhtml')->getUrl('adminhtml/sales_order/index'));
     }
-	
-	public function _remove($order_id){
-		$resource = Mage::getSingleton('core/resource');
-        $delete = $resource->getConnection('core_read');
-        $order_table = $resource->getTableName('sales_flat_order_grid');
-        $invoice_table = $resource->getTableName('sales_flat_invoice_grid');
-        $shipment_table = $resource->getTableName('sales_flat_shipment_grid');
-        $creditmemo_table = $resource->getTableName('sales_flat_creditmemo_grid');
-		$sql = "DELETE FROM  " . $order_table . " WHERE entity_id = " . $order_id . ";";
-        $delete->query($sql);
-		$sql = "DELETE FROM  " . $invoice_table . " WHERE order_id = " . $order_id . ";";
-        $delete->query($sql);
-		$sql = "DELETE FROM  " . $shipment_table . " WHERE order_id = " . $order_id . ";";
-        $delete->query($sql);
-		$sql = "DELETE FROM  " . $creditmemo_table . " WHERE order_id = " . $order_id . ";";
-        $delete->query($sql);
+
+	private function _remove($orderId){
+
+        $this->_removeEntities('sales/order_grid', $orderId, 'entity_id');
+        $this->_removeEntities('sales/order_invoice', $orderId);
+        $this->_removeEntities('sales/order_shipment', $orderId);
+        $this->_removeEntities('sales/order_creditmemo', $orderId);
 		
 		return true;
 	}
+
+	private function _removeEntities($modelClass, $orderId, $columnName = 'order_id')
+    {
+        /** @var Varien_Db_Adapter_Interface $write */
+        $write = Mage::getSingleton('core/resource')
+                     ->getConnection('core_write');
+        /** @var Mage_Core_Model_Resource_Db_Collection_Abstract $collection */
+        $collection = Mage::getResourceModel($modelClass . '_collection');
+        $query      = $collection->getSelect()
+                                 ->where('main_table.' . $columnName . ' = ?',
+                                     $orderId)
+                                 ->deleteFromSelect('main_table');
+        $write->query($query);
+    }
 	
 }


### PR DESCRIPTION
* Added form key validation to delete and massdelete actions to prevent CSRF attacks.
* Removed unparameterized SQL delete queries and replaced with parameterized queries.
* Inherited from Mage_Adminhtml_Block_Sales_Order_Grid and removed all code that was copy/pasted from there.  There's no reason to duplicate that code, since we can call the parent class methods and then just modify the columns and mass actions after the fact.